### PR TITLE
Find mismatched stable identifier versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ A collection of tools to perform QA checks during the Release process.
 ### QA checks to run against the Release database
 
 * CompareSpeciesbyclasses: This check will compare the current release database to the previous release database (for example: `test_reactome_65` and `test_reactome_64`) and compare the number of instances of each class type. When the percent difference is > 10% (where the actual difference is > 1000), the difference will be highlighted as `*** Difference is N% ***` in the output report.
+This QA check requires additional config settings in `auth.properties` to connect tot he previous release database. These properties are: `altDbHost`, `altDbName`, `altDbUser`, `altDbPwd`.
+* FindMismatchedStableIdentifierVersions: This check will find Stable Identifiers that are present in two databases, but have mismatched version numbers.
 This QA check requires additional config settings in `auth.properties` to connect tot he previous release database. These properties are: `altDbHost`, `altDbName`, `altDbUser`, `altDbPwd`. 
 
 ### Running the code

--- a/src/main/java/org/reactome/release/qa/check/FindMismatchedStableIdentifierVersions.java
+++ b/src/main/java/org/reactome/release/qa/check/FindMismatchedStableIdentifierVersions.java
@@ -1,0 +1,63 @@
+package org.reactome.release.qa.check;
+
+import java.util.Set;
+
+import org.gk.model.GKInstance;
+import org.gk.model.ReactomeJavaConstants;
+import org.gk.persistence.MySQLAdaptor;
+import org.reactome.release.qa.annotations.ReleaseQATest;
+import org.reactome.release.qa.common.QAReport;
+
+/**
+ * This class will find Stable Identifiers whose version numbers differ between gk_central and test_reactome_XX
+ * @author sshorser
+ *
+ */
+@ReleaseQATest
+public class FindMismatchedStableIdentifierVersions extends AbstractQACheck implements ChecksTwoDatabases
+{
+	private MySQLAdaptor otherAdaptor;
+
+	@Override
+	public QAReport executeQACheck() throws Exception
+	{
+		QAReport report = new QAReport();
+		report.setColumnHeaders("StableIdentifier", this.dba.getDBName(), this.otherAdaptor.getDBName());
+		@SuppressWarnings("unchecked")
+		Set<GKInstance> gkCentralSTIDs = (Set<GKInstance>) this.otherAdaptor.fetchInstancesByClass(ReactomeJavaConstants.StableIdentifier);
+
+		for (GKInstance gkCentralSTID : gkCentralSTIDs)
+		{
+			String identifier = (String) gkCentralSTID.getAttributeValue(ReactomeJavaConstants.identifier);
+			String version = (String) gkCentralSTID.getAttributeValue(ReactomeJavaConstants.identifierVersion);
+			
+			// This assumes that the DBID from gk_central is used for the same Stable Identifier as in test_reactome_XX.
+			GKInstance testReactomeSTID = this.dba.fetchInstance(gkCentralSTID.getDBID());
+			
+			if (testReactomeSTID!=null && testReactomeSTID.getSchemClass().getName().equals(ReactomeJavaConstants.StableIdentifier))
+			{
+				String testReactomeIdentifierString = (String) testReactomeSTID.getAttributeValue(ReactomeJavaConstants.identifier);
+				String testReactomeIdentifierVersionString = (String) testReactomeSTID.getAttributeValue(ReactomeJavaConstants.identifierVersion);
+				
+				if (identifier.equals(testReactomeIdentifierString) && !version.equals(testReactomeIdentifierVersionString))
+				{
+					report.addLine(testReactomeIdentifierString, version, testReactomeIdentifierVersionString);
+				}
+			}
+		}
+		return report;
+	}
+
+	@Override
+	public String getDisplayName()
+	{
+		return "Find_Mismatched_Stabled_Identifier_Versions";
+	}
+
+	@Override
+	public void setOtherDBAdaptor(MySQLAdaptor adaptor)
+	{
+		this.otherAdaptor = adaptor;
+	}
+
+}


### PR DESCRIPTION
New ReleaseQA check - will search for stable identifiers in two databases that have different version numbers.