### PR TITLE
Fix pe compartment check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ ContributorsCheck/contributors-check/src/main/resources/auth.properties
 .recommenders
 NullCheck/src/main/resources/auth.properties
 auth.properties
+/target/

--- a/src/main/java/org/reactome/release/qa/graph/PhysicalEntitiesCompartmentCheck.java
+++ b/src/main/java/org/reactome/release/qa/graph/PhysicalEntitiesCompartmentCheck.java
@@ -11,7 +11,7 @@ import java.util.List;
 import org.gk.model.GKInstance;
 import org.gk.model.ReactomeJavaConstants;
 import org.gk.schema.GKSchemaAttribute;
-import org.gk.schema.SchemaClass;
+import org.gk.schema.GKSchemaClass;
 import org.reactome.release.qa.annotations.GraphQACheck;
 import org.reactome.release.qa.common.AbstractQACheck;
 import org.reactome.release.qa.common.JavaConstants;
@@ -36,17 +36,17 @@ public class PhysicalEntitiesCompartmentCheck extends AbstractQACheck {
     @SuppressWarnings("unchecked")
     public QAReport executeQACheck() throws Exception {
         QAReport report = new QAReport();
-
-
-        for (SchemaClass sc : ((Collection<SchemaClass>) this.dba.getSchema().getClasses()))
+        // We are interested in all subclasses of PhysicalEntity.
+        GKSchemaClass physicalEntitySchemaClass = (GKSchemaClass) this.dba.getSchema().getClassByName(ReactomeJavaConstants.PhysicalEntity);
+        for (GKSchemaClass schemaClass : (Collection<GKSchemaClass>)physicalEntitySchemaClass.getSubClasses())
         {
             // we can't check the compartment of PhysicalEntity, but we can check all subclasses that have a compartment attribute.
-            if (sc.isa(ReactomeJavaConstants.PhysicalEntity))
+            if (schemaClass.isa(ReactomeJavaConstants.PhysicalEntity))
             {
-                boolean hasCompartment = ((Collection<GKSchemaAttribute>)sc.getAttributes()).stream().anyMatch(a -> a.getName().equals(ReactomeJavaConstants.compartment));
+                boolean hasCompartment = ((Collection<GKSchemaAttribute>)schemaClass.getAttributes()).stream().anyMatch(a -> a.getName().equals(ReactomeJavaConstants.compartment));
                 if (hasCompartment)
                 {
-                    String e2c = QACheckerHelper.getAttributeTableName(sc.getName(),
+                    String e2c = QACheckerHelper.getAttributeTableName(schemaClass.getName(),
                                                                        ReactomeJavaConstants.compartment,
                                                                        dba);
                     String sql = "SELECT DB_ID" +

--- a/src/main/java/org/reactome/release/qa/graph/PhysicalEntitiesCompartmentCheck.java
+++ b/src/main/java/org/reactome/release/qa/graph/PhysicalEntitiesCompartmentCheck.java
@@ -10,6 +10,8 @@ import java.util.List;
 
 import org.gk.model.GKInstance;
 import org.gk.model.ReactomeJavaConstants;
+import org.gk.schema.GKSchemaAttribute;
+import org.gk.schema.SchemaClass;
 import org.reactome.release.qa.annotations.GraphQACheck;
 import org.reactome.release.qa.common.AbstractQACheck;
 import org.reactome.release.qa.common.JavaConstants;
@@ -18,12 +20,12 @@ import org.reactome.release.qa.common.QAReport;
 
 @GraphQACheck
 public class PhysicalEntitiesCompartmentCheck extends AbstractQACheck {
-    
+
     private final static String LOAD_ATTS[] = {ReactomeJavaConstants.inferredFrom, JavaConstants.entityOnOtherCell};
 
     private static final List<String> HEADERS = Arrays.asList(
             "DBID", "DisplayName", "SchemaClass", "MostRecentAuthor");
-    
+
 
     @Override
     public String getDisplayName() {
@@ -35,42 +37,59 @@ public class PhysicalEntitiesCompartmentCheck extends AbstractQACheck {
     public QAReport executeQACheck() throws Exception {
         QAReport report = new QAReport();
 
-        String e2c = QACheckerHelper.getAttributeTableName(ReactomeJavaConstants.PhysicalEntity,
-                                                           ReactomeJavaConstants.compartment,
-                                                           dba);
-        String sql = "SELECT DB_ID" +
-                " FROM " + e2c +
-                " GROUP BY DB_ID" +
-                " HAVING COUNT(" + ReactomeJavaConstants.compartment + ") > 1";
-        Connection conn = dba.getConnection();
-        PreparedStatement ps = conn.prepareStatement(sql);
-        ResultSet rs = ps.executeQuery();
-        List<Long> dbIds = new ArrayList<Long>();
-        while (rs.next()) {
-            dbIds.add(rs.getLong(1));
+
+        for (SchemaClass sc : ((Collection<SchemaClass>) this.dba.getSchema().getClasses()))
+        {
+            // we can't check the compartment of PhysicalEntity, but we can check all subclasses that have a compartment attribute.
+            if (sc.isa(ReactomeJavaConstants.PhysicalEntity))
+            {
+                boolean hasCompartment = ((Collection<GKSchemaAttribute>)sc.getAttributes()).stream().anyMatch(a -> a.getName().equals(ReactomeJavaConstants.compartment));
+                if (hasCompartment)
+                {
+                    String e2c = QACheckerHelper.getAttributeTableName(sc.getName(),
+                                                                       ReactomeJavaConstants.compartment,
+                                                                       dba);
+                    String sql = "SELECT DB_ID" +
+                            " FROM " + e2c +
+                            " GROUP BY DB_ID" +
+                            " HAVING COUNT(" + ReactomeJavaConstants.compartment + ") > 1";
+                    Connection conn = dba.getConnection();
+                    try(PreparedStatement ps = conn.prepareStatement(sql))
+                    {
+                        ResultSet rs = ps.executeQuery();
+                        List<Long> dbIds = new ArrayList<>();
+                        while (rs.next()) {
+                            dbIds.add(rs.getLong(1));
+                        }
+
+                        Collection<GKInstance> entities =
+                                dba.fetchInstances(ReactomeJavaConstants.PhysicalEntity, dbIds);
+                        dba.loadInstanceAttributeValues(entities, LOAD_ATTS);
+
+                        for (GKInstance entity: entities) {
+                            if (isEscaped(entity)) {
+                                continue;
+                            }
+                            // Only report complexes.
+                            if (!entity.getSchemClass().isa(ReactomeJavaConstants.Complex)) {
+                                continue;
+                            }
+                            GKInstance entityOnOtherCell = null;
+                            if (entity.getSchemClass().isValidAttribute(JavaConstants.entityOnOtherCell))
+                                entityOnOtherCell = (GKInstance) entity.getAttributeValue(JavaConstants.entityOnOtherCell);
+                            if (entityOnOtherCell == null) {
+                                report.addLine(entity.getDBID().toString(),
+                                               entity.getDisplayName(),
+                                               entity.getSchemClass().getName(),
+                                               QACheckerHelper.getLastModificationAuthor(entity));
+                            }
+                        }
+                    }
+                }
+            }
         }
-        Collection<GKInstance> entities =
-                dba.fetchInstances(ReactomeJavaConstants.PhysicalEntity, dbIds);
-        dba.loadInstanceAttributeValues(entities, LOAD_ATTS);
-        for (GKInstance entity: entities) {
-            if (isEscaped(entity)) {
-                continue;
-            }
-            // Only report complexes.
-            if (!entity.getSchemClass().isa(ReactomeJavaConstants.Complex)) {
-                continue;
-            }
-            GKInstance entityOnOtherCell = null;
-            if (entity.getSchemClass().isValidAttribute(JavaConstants.entityOnOtherCell))
-                entityOnOtherCell = (GKInstance) entity.getAttributeValue(JavaConstants.entityOnOtherCell);
-            if (entityOnOtherCell == null) {
-                report.addLine(entity.getDBID().toString(), 
-                               entity.getDisplayName(), 
-                               entity.getSchemClass().getName(), 
-                               QACheckerHelper.getLastModificationAuthor(entity));
-            }
-        }
-        
+
+
         report.setColumnHeaders(HEADERS);
 
         return report;


### PR DESCRIPTION
This fixes an issue where the PhysicalEntity compartment check failed because the attribute was removed from PhysicalEntity, though it still exists on some subclasses.

The fix involves checking all subclasses of PhysicalEntity for the "compartment" attribute before attempting anything else.