### PR TITLE
Feature/update cov2 literature check

### DIFF
--- a/src/main/java/org/reactome/release/qa/check/CoV2InfectionPathwayEventCheck.java
+++ b/src/main/java/org/reactome/release/qa/check/CoV2InfectionPathwayEventCheck.java
@@ -54,7 +54,7 @@ public class CoV2InfectionPathwayEventCheck extends AbstractQACheck {
             // issue is being reported, it indicates they likely made an error.
             // If literatureReference attribute does not contain at least 1 litRef from 2020.
             if (cov2Event.getAttributeValue(ReactomeJavaConstants.inferredFrom) == null && !hasRecentLiteratureReference(cov2Event)) {
-                issues.add("Does not contain a 2020 literature reference");
+                issues.add("Does not contain a literature reference from 2020 or later");
             }
             // Summation text was updated near end of release cycle where CoV-1-to-CoV-2 projections happened.
             // If it didn't have the updated text, there are two reasons for it, outlined below.

--- a/src/main/java/org/reactome/release/qa/check/CoV2InfectionPathwayEventCheck.java
+++ b/src/main/java/org/reactome/release/qa/check/CoV2InfectionPathwayEventCheck.java
@@ -143,7 +143,7 @@ public class CoV2InfectionPathwayEventCheck extends AbstractQACheck {
      * instance
      */
     private boolean literatureReferenceFromOrLaterThan2020(GKInstance literatureReference) throws Exception {
-        if (literatureReference.getSchemClass().isa(ReactomeJavaConstants.LiteratureReference)) {
+        if (!literatureReference.getSchemClass().isa(ReactomeJavaConstants.LiteratureReference)) {
             return false;
         }
 
@@ -159,7 +159,7 @@ public class CoV2InfectionPathwayEventCheck extends AbstractQACheck {
      * @throws Exception, thrown by MySQLAdaptor if unable to get attribute values from the URL instance
      */
     private boolean urlFromOrLaterThan2020(GKInstance url) throws Exception {
-        if (url.getSchemClass().isa(ReactomeJavaConstants.URL)) {
+        if (!url.getSchemClass().isa(ReactomeJavaConstants.URL)) {
             return false;
         }
 


### PR DESCRIPTION
This checks to make sure the literature publications for cov-2 are from 2020 or later. Needs review to see if it is ready. 