### PR TITLE
Feature/log4j2 v2.16.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,7 @@ ContributorsCheck/contributors-check/src/main/resources/auth.properties
 NullCheck/src/main/resources/auth.properties
 auth.properties
 /target/
+
+# IntelliJ Files
+.idea/
+*.iml

--- a/pom.xml
+++ b/pom.xml
@@ -167,7 +167,7 @@
 		<dependency>
 			<groupId>org.reactome.release</groupId>
 			<artifactId>release-common-lib</artifactId>
-			<version>1.2.0</version>
+			<version>1.2.3-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>junit</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 			resources, i.e. build is platform dependent! See: https://maven.apache.org/general.html -->
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<opencsv.version>4.2</opencsv.version>
-		<log4j2.version>2.11.0</log4j2.version>
+		<log4j2.version>2.16.0</log4j2.version>
 		<javax.mail.version>1.4</javax.mail.version>
 		<reactome.base.version>2.1.0-SNAPSHOT</reactome.base.version>
 	</properties>

--- a/src/main/java/org/reactome/release/qa/common/AbstractQACheck.java
+++ b/src/main/java/org/reactome/release/qa/common/AbstractQACheck.java
@@ -102,7 +102,7 @@ public abstract class AbstractQACheck implements QACheck {
         if (ieDateValue == null) {
             return true;
         }
-        DateFormat df = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.S");
+        DateFormat df = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
         Date ieDate = df.parse(ieDateValue);
         return !ieDate.after(CUTOFF_DATE);
     }


### PR DESCRIPTION
We need to upgrade the reactome-common-lib version to the latest and the log4j version to the latest. 

We need to figure out if the millisecond change is fixing a bug and determine if we should be making the change. 